### PR TITLE
Documentation: Fix typo on the pdf-setup command

### DIFF
--- a/packages/anon-aadhaar-pcd/README.md
+++ b/packages/anon-aadhaar-pcd/README.md
@@ -37,5 +37,5 @@ yarn test
 Generate pdf file with pkcs#1 schema. This action will create pdf file name `signed.pdf` signed by `certificate.cer` in `build` folder.
 
 ```bash
-./script/setup-dev.sh pdf_setup
+./script/setup-dev.sh pdf-setup
 ```


### PR DESCRIPTION
## Motivation

The following command in the `pcd` readme is not working `./script/setup-dev.sh pdf_setup` it works by running it the following way `bash ./script/setup-dev.sh pdf-setup`.

## Change Summary

Fixed a typo on the Readme page

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [change set](https://github.com/privacy-scaling-explorations/anon-aadhaar/CHANGELOG.md)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bug fix, or chore)
- [ ] PR includes documentation if necessary.