### PR TITLE
fix: signal hash and message sender comparator

### DIFF
--- a/packages/contracts/src/example/AnonAadhaarVote.sol
+++ b/packages/contracts/src/example/AnonAadhaarVote.sol
@@ -29,9 +29,19 @@ contract AnonAadhaarVote is IAnonAadhaarVote {
 
     /// @dev Convert an address to uint256, used to check against signal.
     /// @param _addr: msg.sender address.
-    /// @return Address msg.sender's address in uint256
-    function addressToUint256(address _addr) private pure returns (uint256) {
-        return uint256(uint160(_addr));
+    /// @return Address msg.sender's hashed address in uint256
+    function signalHashVerifier(address _addr) private pure returns (uint256) {
+         // Convert address to uint256
+        uint256 addrAsUint = uint256(uint160(_addr));
+        
+        // Pad to 32 bytes (256 bits)
+        bytes32 paddedAddr = bytes32(addrAsUint);
+        
+        // Apply keccak256 hash
+        bytes32 hashed = keccak256(abi.encodePacked(paddedAddr));
+        
+        // Shift right by 3 bits and return
+        return uint256(hashed) >> 3;
     }
 
     /// @dev Check if the timestamp is more recent than (current time - 3 hours)
@@ -63,7 +73,7 @@ contract AnonAadhaarVote is IAnonAadhaarVote {
             '[AnonAadhaarVote]: Invalid proposal index'
         );
         require(
-            addressToUint256(msg.sender) == signal,
+            signalHashVerifier(msg.sender) == signal,
             '[AnonAadhaarVote]: Wrong user signal sent.'
         );
         require(


### PR DESCRIPTION
## Motivation
The current implementation of the `addressToUint256` function in the smart contract is incompatible with the signal hash generation method used by the library. This mismatch causes the user signal verification to fail consistently, preventing the intended functionality of the AnonAadhaarVote system.

## Change Summary
Replace the `addressToUint256` function with a new `signalHashVerifier` function that correctly implements the hashing process to match the library's signal generation method.

## Merge Checklist
- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [change set](https://github.com/anon-aadhaar/anon-aadhaar/blob/main/CHANGELOG.md)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bug fix, or chore)
- [x] PR includes documentation if necessary.

## Additional Context
This change addresses a critical issue in the AnonAadhaarVote system where user signal verification was failing due to a mismatch between the contract's hashing method and the library's signal generation. The new `signalHashVerifier` function implements the following steps to match the library's hashing process:

1. Convert the address to uint256
2. Pad to 32 bytes (256 bits)
3. Apply keccak256 hash
4. Shift right by 3 bits

This change ensures compatibility between the contract and the library, allowing for correct user signal verification. The fix is crucial for the proper functioning of the AnonAadhaarVote system and should be thoroughly tested to ensure it resolves the issue without introducing new problems.