### PR TITLE
Fix typo in useProver hook documentation Update README.md

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -184,5 +184,5 @@ function YourComponent() {
 
 | Return Value      | Description                                                                                                                                |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ProverState`     | The current state of the proof generation processwith relevant state details.                                                              |
+| `ProverState`     | The current state of the proof generation process with relevant state details.                                                              |
 | `AnonAadhaarCore` | Represents the deserialized proof of authentication, if available, indicating a successful proof generation. Otherwise, it is `undefined`. |


### PR DESCRIPTION
**Description**:

This pull request fixes a minor typographical error in the documentation for the `useProver` hook. Specifically, in the table describing the return values, the description for `ProverState` was missing a space between the words "process" and "with."

**Incorrect**:

- "The current state of the proof generation processwith relevant state details."

**Corrected**:

- "The current state of the proof generation process with relevant state details."

**Importance**:
This correction improves the readability of the documentation and ensures that users can clearly understand the description. While minor, such errors can create confusion, especially in technical documentation where clarity is crucial for developers working with the code.

Thank you for reviewing this fix!


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [change set](https://github.com/anon-aadhaar/anon-aadhaar/blob/main/CHANGELOG.md)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bug fix, or chore)
- [ ] PR includes documentation if necessary.