### PR TITLE
fix: increased ptau + fix hash caching

### DIFF
--- a/packages/circuits/scripts/build.sh
+++ b/packages/circuits/scripts/build.sh
@@ -3,7 +3,7 @@
 
 # default dir
 BUILD_DIR="$(pwd)/build"
-PTAU="powersOfTau28_hez_final_20.ptau"
+PTAU="powersOfTau28_hez_final_21.ptau"
 PTAU_PATH="$BUILD_DIR/$PTAU"
 CONTRACTS_DIR="$(pwd)/../contracts/src"
 JS_BUILD_DIR="$BUILD_DIR/aadhaar-verifier_js"
@@ -54,7 +54,7 @@ function build_circuit() {
 function dev_trusted_setup() {
     echo "Starting setup...!"
 
-    HASH=$(pwd)/scripts/utils.sh
+    HASH=$(./scripts/utils.sh)
 
     if [ -f "$BUILD_DIR"/hash.txt ]; then 
         OLD_HASH=`cat "$BUILD_DIR"/hash.txt`


### PR DESCRIPTION
## Motivation

This PR fix: 
- A bug in the caching of the circuit dev trusted setup: https://github.com/anon-aadhaar/anon-aadhaar/pull/235
- An inflation in the number of constraints introduced by a new version of the Circom compiler

## Change Summary

- Fix line generating the circuit files hash in the `packages/circuit/scripts/build.sh` script
- Switch ptau to 2^21

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [change set](https://github.com/anon-aadhaar/anon-aadhaar/blob/main/CHANGELOG.md)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bug fix, or chore)
- [x] PR includes documentation if necessary.