### PR TITLE
fix: Fix missing node call in script execution Update build.sh

### DIFF
--- a/packages/circuits/scripts/build.sh
+++ b/packages/circuits/scripts/build.sh
@@ -75,7 +75,7 @@ function dev_trusted_setup() {
 
     echo "test random" | NODE_OPTIONS='--max-old-space-size=8192' \
 	node $SNARKJS_PATH zkey contribute "$PARTIAL_ZKEYS_DIR"/circuit_0000.zkey "$PARTIAL_ZKEYS_DIR"/circuit_final.zkey --name="1st Contributor Name" -v 
-    NODE_OPTIONS='--max-old-space-size=8192' $SNARKJS_PATH zkey export verificationkey "$PARTIAL_ZKEYS_DIR"/circuit_final.zkey "$BUILD_DIR"/vkey.json
+    NODE_OPTIONS='--max-old-space-size=8192' node $SNARKJS_PATH zkey export verificationkey "$PARTIAL_ZKEYS_DIR"/circuit_final.zkey "$BUILD_DIR"/vkey.json
     fi
     
     if [ ! -d "$ARTIFACTS_DIR" ]; then


### PR DESCRIPTION
## Motivation

The script referenced by `$SNARKJS_PATH` wasn't being executed correctly because the `node` command was missing. Without it, the shell tries to run the script directly, causing an error.

This fix ensures the script is properly executed via Node.js.  

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [change set](https://github.com/anon-aadhaar/anon-aadhaar/blob/main/CHANGELOG.md)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bug fix, or chore)
- [x] PR includes documentation if necessary.