### PR TITLE
readme: update invalid demo app resource link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.4
+
+- Fix invalid demo app resource link in README
+
 ## 2.4.3
 
 - Fix type error in utils function `searchZkeyChunks`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 2.4.4
-
-- Fix invalid demo app resource link in README
-
 ## 2.4.3
 
 - Fix type error in utils function `searchZkeyChunks`

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Anon Aadhaar is a protocol for proving ownership of an Aadhaar identity (Indian 
 
 Developers can use the AnonAadhaar SDK to integrate this into their applications to verify the identity of users without asking them to reveal more personal data than necessary. The proof generated can also be verified on EVM-based blockchains making Anon Aadhaar suitable for on-chain applications.
 
-Demo App: [Anon Aadhaar Example](https://boilerplate.anon-aadhaar.pse.dev/)  |  [Source](https://github.com/anon-aadhaar-private/boilerplate)
+Demo App: [Anon Aadhaar Example](https://boilerplate.anon-aadhaar.pse.dev/)  |  [Source](https://github.com/anon-aadhaar/boilerplate)
 
 Documentation: [Anon Aadhaar Documentation](https://documentation.anon-aadhaar.pse.dev/docs/intro)
 


### PR DESCRIPTION
## Motivation

The demo app link in the README was outdated. This PR updates it to point to the correct and active resource.

## Change Summary

Replaced the invalid demo app link in the README with the correct one.

## Merge Checklist
- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [change set](https://github.com/anon-aadhaar/anon-aadhaar/blob/main/CHANGELOG.md)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bug fix, or chore)
- [x] PR includes documentation if necessary.

I was not able to add a label.
